### PR TITLE
찜 + 찜 취소 api 

### DIFF
--- a/src/main/java/com/switcheese/server/common/exception/KeyBoardNotFoundException.java
+++ b/src/main/java/com/switcheese/server/common/exception/KeyBoardNotFoundException.java
@@ -1,0 +1,12 @@
+package com.switcheese.server.common.exception;
+
+public class KeyBoardNotFoundException extends BusinessException {
+
+  private final SampleErrorCode code;
+
+  public KeyBoardNotFoundException(SampleErrorCode code, Object... args) {
+    super(code.getStatus(), code.toString(), code.getMessage(), args);
+    this.code = code;
+  }
+
+}

--- a/src/main/java/com/switcheese/server/common/exception/SampleErrorCode.java
+++ b/src/main/java/com/switcheese/server/common/exception/SampleErrorCode.java
@@ -5,11 +5,12 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum SampleErrorCode {
-  NOT_FOUND_USER(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다. : [%s]");
+  NOT_FOUND_USER(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다. : [%s]"),
+  NOT_FOUND_KEYBOARD_SWITCH(HttpStatus.NOT_FOUND, "스위치를 찾을 수 없습니다. [%s]");
 
   private final HttpStatus status;
   private final String message;
-  
+
   SampleErrorCode(HttpStatus status, String message) {
     this.status = status;
     this.message = message;

--- a/src/main/java/com/switcheese/server/keyboardSwitch/application/wish/WishService.java
+++ b/src/main/java/com/switcheese/server/keyboardSwitch/application/wish/WishService.java
@@ -1,0 +1,47 @@
+package com.switcheese.server.keyboardSwitch.application.wish;
+
+import static com.switcheese.server.common.exception.SampleErrorCode.NOT_FOUND_KEYBOARD_SWITCH;
+import static com.switcheese.server.common.exception.SampleErrorCode.NOT_FOUND_USER;
+
+import com.switcheese.server.common.exception.KeyBoardNotFoundException;
+import com.switcheese.server.common.exception.NoSuchMemberException;
+import com.switcheese.server.keyboardSwitch.domain.KeyboardSwitchRepository;
+import com.switcheese.server.keyboardSwitch.domain.WishRepository;
+import com.switcheese.server.keyboardSwitch.domain.model.KeyboardSwitch;
+import com.switcheese.server.keyboardSwitch.domain.model.Wish;
+import com.switcheese.server.keyboardSwitch.presentation.dto.WishSwitchRequest;
+import com.switcheese.server.member.domain.MemberRepository;
+import com.switcheese.server.member.domain.model.Member;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class WishService {
+
+  private WishRepository wishRepository;
+  private MemberRepository memberRepository;
+  private KeyboardSwitchRepository keyboardSwitchRepository;
+
+  public WishService(WishRepository wishRepository, MemberRepository memberRepository,
+      KeyboardSwitchRepository keyboardSwitchRepository) {
+    this.wishRepository = wishRepository;
+    this.memberRepository = memberRepository;
+    this.keyboardSwitchRepository = keyboardSwitchRepository;
+  }
+
+  @Transactional
+  public void wishSwitch(WishSwitchRequest request, Long memberId) {
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new NoSuchMemberException(NOT_FOUND_USER));
+    KeyboardSwitch keyboardSwitch = keyboardSwitchRepository.findByIdAndIsDeleteFalse(
+            request.switchId())
+        .orElseThrow(() -> new KeyBoardNotFoundException(NOT_FOUND_KEYBOARD_SWITCH));
+
+    wishRepository.findByMemberAndKeyboardSwitch(member,
+        keyboardSwitch).ifPresentOrElse(
+        wish -> wish.turnActive(request.active()),
+        () -> wishRepository.save(new Wish(member, keyboardSwitch, request.active()))
+    );
+  }
+
+}

--- a/src/main/java/com/switcheese/server/keyboardSwitch/domain/KeyboardSwitchRepository.java
+++ b/src/main/java/com/switcheese/server/keyboardSwitch/domain/KeyboardSwitchRepository.java
@@ -1,0 +1,11 @@
+package com.switcheese.server.keyboardSwitch.domain;
+
+import com.switcheese.server.keyboardSwitch.domain.model.KeyboardSwitch;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface KeyboardSwitchRepository extends JpaRepository<KeyboardSwitch, Long> {
+
+  Optional<KeyboardSwitch> findByIdAndIsDeleteFalse(Long id);
+
+}

--- a/src/main/java/com/switcheese/server/keyboardSwitch/domain/WishRepository.java
+++ b/src/main/java/com/switcheese/server/keyboardSwitch/domain/WishRepository.java
@@ -1,0 +1,13 @@
+package com.switcheese.server.keyboardSwitch.domain;
+
+import com.switcheese.server.keyboardSwitch.domain.model.KeyboardSwitch;
+import com.switcheese.server.keyboardSwitch.domain.model.Wish;
+import com.switcheese.server.member.domain.model.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WishRepository extends JpaRepository<Wish, Long> {
+
+  Optional<Wish> findByMemberAndKeyboardSwitch(Member member, KeyboardSwitch keyboardSwitch);
+
+}

--- a/src/main/java/com/switcheese/server/keyboardSwitch/domain/model/Wish.java
+++ b/src/main/java/com/switcheese/server/keyboardSwitch/domain/model/Wish.java
@@ -34,6 +34,16 @@ public class Wish extends BaseEntity {
   @JoinColumn(name = "switch_id", nullable = false)
   private KeyboardSwitch keyboardSwitch;
 
-  private Boolean isDelete;
+  private Boolean isActive;
+
+  public Wish(Member member, KeyboardSwitch keyboardSwitch, Boolean isActive) {
+    this.member = member;
+    this.keyboardSwitch = keyboardSwitch;
+    this.isActive = isActive;
+  }
+
+  public void turnActive(Boolean isActive) {
+    this.isActive = isActive;
+  }
 
 }

--- a/src/main/java/com/switcheese/server/keyboardSwitch/presentation/dto/WishSwitchRequest.java
+++ b/src/main/java/com/switcheese/server/keyboardSwitch/presentation/dto/WishSwitchRequest.java
@@ -1,0 +1,5 @@
+package com.switcheese.server.keyboardSwitch.presentation.dto;
+
+public record WishSwitchRequest(Long switchId, Boolean active) {
+
+}

--- a/src/main/java/com/switcheese/server/keyboardSwitch/presentation/wish/WishController.java
+++ b/src/main/java/com/switcheese/server/keyboardSwitch/presentation/wish/WishController.java
@@ -1,0 +1,29 @@
+package com.switcheese.server.keyboardSwitch.presentation.wish;
+
+import com.switcheese.server.keyboardSwitch.application.wish.WishService;
+import com.switcheese.server.keyboardSwitch.presentation.dto.WishSwitchRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/wish")
+public class WishController {
+
+  private WishService wishService;
+
+  public WishController(WishService wishService) {
+    this.wishService = wishService;
+  }
+
+  @PostMapping("")
+  public ResponseEntity<Void> wishSwitch(@RequestHeader("memberId") Long memberId,
+      @ModelAttribute WishSwitchRequest request) {
+    wishService.wishSwitch(request, memberId);
+    return ResponseEntity.noContent().build();
+  }
+
+}

--- a/src/test/http/wish.http
+++ b/src/test/http/wish.http
@@ -1,0 +1,3 @@
+### 찜 api
+POST {{url}}/wish?switchId=1&active=false
+memberId:1


### PR DESCRIPTION
is_delete -> is_active 로 바꿔서 찜할때마다 쌓이는게 아니라 is_active 필드를 토글하면서 찜, 찜 취소를 왔다갔다하는 방식을 생각했습니다
그래서 필드명도 임의로 바꿨는데 의견 부탁드립니다
혹시 몰라서 노션에 db ddl도 is_delete -> is_active 로 수정해두었습니다

### ✅ What is this PR

- 찜 + 찜 취소 api 개발


### 🙋🏻‍ Review Point

- WishService. wishSwitch() 에서 쿼리 세번 날리는게 최선인가요 원래?



### Reference

Issue #8
